### PR TITLE
fix(cache): clone embeddings before save to avoid persisting whole ba…

### DIFF
--- a/src/miniclip/cached_text_embedding.py
+++ b/src/miniclip/cached_text_embedding.py
@@ -330,6 +330,17 @@ class CachedTextEmbedding:
         """Save an embedding tensor to cache and return its path."""
         tensor_path = self._get_tensor_path(cache_key)
         
+        # Detach per-sample tensors from any shared (batch) backing storage before save.
+        # Per-batch embeddings are row VIEWS into a [batch, dim] tensor; torch.save persists
+        # the whole underlying storage, bloating each .pt to batch_size*dim (e.g.
+        # 128*4096*4B ~= 2MB vs 16KB). clone() gives each row its own contiguous storage.
+        def _compact(t):
+            return t.detach().cpu().clone().contiguous() if torch.is_tensor(t) else t
+        if isinstance(embedding, dict):
+            embedding = {k: _compact(v) for k, v in embedding.items()}
+        else:
+            embedding = _compact(embedding)
+
         # Save tensor
         torch.save(embedding, tensor_path)
         


### PR DESCRIPTION
Fixes #12

Compatibility / Impact
Non-breaking. Existing caches still load correctly (values are unchanged); no migration is required.
After the fix, newly built caches shrink from batch_size × dim to dim per file (e.g. 16× smaller at --batch-size 16, 128× at --batch-size 128). Old caches can optionally be rebuilt to reclaim disk.
Embedding values are bit-for-bit identical — no effect on any already-trained or in-progress models.
Train-time side benefit: torch.load no longer pulls the entire [batch, dim] storage into memory per sample, reducing DataLoader memory and disk I/O.
Verification
Build a cache before and after the fix from the same input and assert:

Values unchanged — loaded vectors are bitwise-equal.
Size fixed — per-file size is on the order of dim × 4 bytes and no longer scales with batch_size.
import torch, os

emb = torch.load(path, map_location="cpu")["all_findings"]   # dict value

# 1) values: identical to a freshly-cloned compute (no change in numbers)
assert torch.equal(emb, emb.clone())

# 2) size: file no longer carries the whole batch storage
real = emb.numel() * emb.element_size()                      # dim * 4B  (e.g. 16 KB)
print("file:", os.path.getsize(path), " real tensor:", real)
print("storage elems:", emb.untyped_storage().nbytes() // emb.element_size())  # == dim, not batch*dim
print("storage_offset:", emb.storage_offset())               # 0 after fix (was i*dim)
Before the fix: file ≈ batch_size × dim × 4B, storage elems == batch_size × dim, storage_offset == i × dim.
After the fix: file ≈ dim × 4B, storage elems == dim, storage_offset == 0.